### PR TITLE
Added cryptography as install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='libify',
-      version='0.78',
+      version='0.79',
       author='Madhup Sukoon',
       author_email='29144316+vagrantism@users.noreply.github.com',
       description='Import Databricks notebooks as libraries/modules',
@@ -20,4 +20,7 @@ setup(name='libify',
         'Operating System :: OS Independent',
     ],
     python_requires='>=3.5',
+    install_requires=[
+      'cryptography>=37.0.2',
+    ],
     zip_safe=False)


### PR DESCRIPTION
fix #7 

---

I have tried to install the updated package locally to see whether pip handles the dependency as expected.

```bash
$ python setup.py bdist_wheel
running bdist_wheel
running build
...

$ ls dist
libify-0.79-py3-none-any.whl

$ pip install --find-links=dist/libify-0.79-py3-none-any.whl libify
Looking in links: dist/libify-0.79-py3-none-any.whl
Processing ./dist/libify-0.79-py3-none-any.whl
Collecting cryptography>=37.0.2
...
Successfully installed cryptography-37.0.2 libify-0.79

$ python -c "import libify"

# no error
```